### PR TITLE
Update store-gifting.sp

### DIFF
--- a/scripting/store-gifting.sp
+++ b/scripting/store-gifting.sp
@@ -102,7 +102,7 @@ LoadConfig()
 	KvGetString(kv, "gifting_commands", buffer, sizeof(buffer), "!gift /gift");
 	Store_RegisterChatCommands(buffer, ChatCommand_Gift);
 
-	KvGetString(kv, "gifting_commands", buffer, sizeof(buffer), "!accept /accept");
+	KvGetString(kv, "accept_commands", buffer, sizeof(buffer), "!accept /accept");
 	Store_RegisterChatCommands(buffer, ChatCommand_Accept);
 	
 	new String:creditChoices[MAX_CREDIT_CHOICES][10];


### PR DESCRIPTION
Fixed a bug on line 105 : gifting_commands is used twice, accept_commands is the correct call for the line.
